### PR TITLE
Add Videos and MediaIndexing permissions

### DIFF
--- a/harbour-opal-gallery.desktop
+++ b/harbour-opal-gallery.desktop
@@ -16,6 +16,6 @@ Name[en]=Opal Gallery
 Name[de]=Opal-Galerie
 
 [X-Sailjail]
-Permissions=
+Permissions=Videos;MediaIndexing
 OrganizationName=harbour-opal-gallery
 ApplicationName=harbour-opal-gallery


### PR DESCRIPTION
The MediaPlayer page needs both Videos and MediaIndexing in order to work